### PR TITLE
fix: only load umami in production env

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,12 +23,6 @@
     -->
     <title>HG09i Klassentreffen</title>
 
-    <script
-      async
-      defer
-      data-website-id="ac2e5b24-87d2-49b9-9702-35d21ae7c7ba"
-      src="https://umami-eta-one.vercel.app/umami.js"
-    ></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,14 @@ ReactDOM.render(
         <App />
       </>
     </ThemeProvider>
+    {process.env.NODE_ENV === 'production' && (
+      <script
+          async
+          defer
+          data-website-id="ac2e5b24-87d2-49b9-9702-35d21ae7c7ba"
+          src="https://umami-eta-one.vercel.app/umami.js"
+      ></script>
+    )}
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
Als Erstes ist mir aufgefallen, dass Umami Analytics Events auch lokal gesendet werden. Ich würde daher vorschlagen diesen Check einzubauen, welcher dafür sorgen sollte, dass die Events nur noch von der Live Seite versendet werden.